### PR TITLE
Properly focus widgets

### DIFF
--- a/src/modules/focus-callout.js
+++ b/src/modules/focus-callout.js
@@ -25,6 +25,14 @@ function addCallout( section, type ) {
 		}
 	}
 
+	// Highlight widget
+	if ( section && section.container && type === 'widget' ) {
+		debug ( 'highlighting widget container' );
+		callout( section.container );
+		// focus the first input, not the stupid toggle
+		return section.container.find( ':input' ).not( 'button' ).first().focus()
+	}
+
 	// Highlight whatever is focused
 	const focused = $( ':focus' );
 	if ( focused.length ) {


### PR DESCRIPTION
Before: only the widget container toggle would be focused/bounced.

After: the whole widget container gets bounced and the first form field is focused.
