### PR TITLE
Wrap the callback for document.ready in a function properly

### DIFF
--- a/src/preview.js
+++ b/src/preview.js
@@ -31,5 +31,5 @@ function startDirectManipulation() {
 
 api.bind( 'preview-ready', () => {
 	// the widget customizer doesn't run until document.ready, so let's run later
-	$( getWindow().document ).ready( setTimeout( startDirectManipulation, 100 ) );
+	$( getWindow().document ).ready( () => setTimeout( startDirectManipulation, 100 ) );
 } );


### PR DESCRIPTION
I think the original code was intended to call `setTimeout()` when the document is ready,
but it will be invoked immediately when `preview-ready` event fires due to lack of the wrapper function.
