### PR TITLE
Introduce customize_direct_manipulation_disabled_modules filter and support for disabling edit-post-links module

### DIFF
--- a/customize-direct-manipulation.php
+++ b/customize-direct-manipulation.php
@@ -151,9 +151,26 @@ class Jetpack_Customizer_DM {
 	}
 
 	public function add_script_data_in_footer() {
+
+		/**
+		 * Filters the disabled modules Customize Direct Manipulation.
+		 *
+		 * Plugins can push modules onto this list to disable aspects of the plugin.
+		 * For example, the Customize Posts plugin can disable the 'edit-post-links'
+		 * module because it has its own integration with the edit post links
+		 * whereby the posts can be edited in the customizer directly.
+		 *
+		 * Not all modules can currently be disabled.
+		 *
+		 * @param array $disabled_modules Disabled modules, defaulting to empty array.
+		 * @returns array Disabled modules.
+		 */
+		$disabled_modules = apply_filters( 'customize_direct_manipulation_disabled_modules', array() );
+
 		wp_localize_script( 'customize-dm-preview', '_Customizer_DM', array(
 			'menus' => $this->get_menu_data(),
-			'headerImageSupport' => current_theme_supports( 'custom-header' )
+			'headerImageSupport' => current_theme_supports( 'custom-header' ),
+			'disabledModules' => $disabled_modules,
 		) );
 	}
 

--- a/customize-direct-manipulation.php
+++ b/customize-direct-manipulation.php
@@ -153,7 +153,7 @@ class Jetpack_Customizer_DM {
 	public function add_script_data_in_footer() {
 
 		/**
-		 * Filters the disabled modules Customize Direct Manipulation.
+		 * Filters the modules to disable in the Customize Direct Manipulation plugin.
 		 *
 		 * Plugins can push modules onto this list to disable aspects of the plugin.
 		 * For example, the Customize Posts plugin can disable the 'edit-post-links'

--- a/src/preview.js
+++ b/src/preview.js
@@ -24,10 +24,12 @@ function startDirectManipulation() {
 	const footers = getFooterElements();
 	makeFocusable( basicElements.concat( headers, widgets, menus, footers ) );
 
-	if ( isSafari() && ! isMobileSafari() ) {
-		disableEditPostLinks( '.post-edit-link, [href^="https://wordpress.com/post"], [href^="https://wordpress.com/page"]' );
-	} else {
-		modifyEditPostLinks( '.post-edit-link, [href^="https://wordpress.com/post"], [href^="https://wordpress.com/page"]' );
+	if ( -1 === options.disabledModules.indexOf( 'edit-post-links' ) ) {
+		if ( isSafari() && ! isMobileSafari() ) {
+			disableEditPostLinks( '.post-edit-link, [href^="https://wordpress.com/post"], [href^="https://wordpress.com/page"]' );
+		} else {
+			modifyEditPostLinks( '.post-edit-link, [href^="https://wordpress.com/post"], [href^="https://wordpress.com/page"]' );
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #22 via https://github.com/xwp/wp-customize-posts/issues/234
