### PR TITLE
Fix/hidden icon position

### DIFF
--- a/src/helpers/icon-buttons.js
+++ b/src/helpers/icon-buttons.js
@@ -82,7 +82,12 @@ function findOrCreateIcon( element ) {
 	if ( $icon.length ) {
 		return $icon;
 	}
-	return createAndAppendIcon( element.id, element.icon );
+
+	// generate the icon title from the icon type
+	const elementType = element.type.replace(/[A-Z]/g, (ch) => ` ${ch.toLowerCase()}`).trim();
+	const title = `Click to edit the ${elementType}`;
+
+	return createAndAppendIcon( element.id, element.icon, title );
 }
 
 function getIconClassName( id ) {
@@ -125,18 +130,18 @@ function adjustCoordinates( coords ) {
 	return coords;
 }
 
-function createIcon( id, iconType ) {
+function createIcon( id, iconType, title ) {
 	const iconClassName = getIconClassName( id );
 	switch ( iconType ) {
 		case 'headerIcon':
-			return $( `<div class="cdm-icon cdm-icon--header-image ${iconClassName}">${icons.headerIcon}</div>` );
+			return $( `<div class="cdm-icon cdm-icon--header-image ${iconClassName}" title="${title}">${icons.headerIcon}</div>` );
 		default:
-			return $( `<div class="cdm-icon cdm-icon--text ${iconClassName}">${icons.editIcon}</div>` );
+			return $( `<div class="cdm-icon cdm-icon--text ${iconClassName}" title="${title}">${icons.editIcon}</div>` );
 	}
 }
 
-function createAndAppendIcon( id, iconType ) {
-	const $icon = createIcon( id, iconType );
+function createAndAppendIcon( id, iconType, title ) {
+	const $icon = createIcon( id, iconType, title );
 	$( getWindow().document.body ).append( $icon );
 	return $icon;
 }

--- a/src/helpers/icon-buttons.js
+++ b/src/helpers/icon-buttons.js
@@ -93,26 +93,28 @@ function getIconClassName( id ) {
 }
 
 function getCalculatedCssForIcon( position, $target, $icon ) {
+	const hiddenIconPos = ( 'rtl' === document.dir ) ? { right: -1000, left: 'auto' } : { left: -1000, right: 'auto' };
+
 	if ( ! $target.is( ':visible' ) ) {
-		return { left: -1000 };
+		return hiddenIconPos;
 	}
 	const { left, top } = $target.offset();
 	const middle = $target.innerHeight() / 2;
 	const iconMiddle = $icon.innerHeight() / 2;
 	if ( top < 1 ) {
 		debug( 'top offset is unusually low for', $target, top );
-		return { left: -1000 };
+		return hiddenIconPos;
 	}
 	if ( middle < 1 ) {
 		debug( 'middle height is unusually low for', $target, middle );
-		return { left: -1000 };
+		return hiddenIconPos;
 	}
 	if ( position === 'middle' ) {
-		return adjustCoordinates( { top: top + middle - iconMiddle, left } );
+		return adjustCoordinates( { top: top + middle - iconMiddle, left, right: 'auto' } );
 	} else if ( position === 'top-right' ) {
-		return adjustCoordinates( { top, left: left + $target.width() + 70 } );
+		return adjustCoordinates( { top, left: left + $target.width() + 70, right: 'auto' } );
 	}
-	return adjustCoordinates( { top, left } );
+	return adjustCoordinates( { top, left, right: 'auto' } );
 }
 
 function adjustCoordinates( coords ) {

--- a/src/helpers/icon-buttons.js
+++ b/src/helpers/icon-buttons.js
@@ -83,9 +83,7 @@ function findOrCreateIcon( element ) {
 		return $icon;
 	}
 
-	// generate the icon title from the icon type
-	const elementType = element.type.replace(/[A-Z]/g, (ch) => ` ${ch.toLowerCase()}`).trim();
-	const title = `Click to edit the ${elementType}`;
+	const title = `Click to edit the ${element.title}`;
 
 	return createAndAppendIcon( element.id, element.icon, title );
 }

--- a/src/modules/footer-focus.js
+++ b/src/modules/footer-focus.js
@@ -4,7 +4,8 @@ export function getFooterElements() {
 			id: 'footercredit',
 			selector: 'a[data-type="footer-credit"]',
 			type: 'footerCredit',
-			position: 'middle'
+			position: 'middle',
+			title: 'footer credit',
 		}
 	];
 }

--- a/src/modules/footer-focus.js
+++ b/src/modules/footer-focus.js
@@ -3,7 +3,7 @@ export function getFooterElements() {
 		{
 			id: 'footercredit',
 			selector: 'a[data-type="footer-credit"]',
-			type: 'footer',
+			type: 'footerCredit',
 			position: 'middle'
 		}
 	];

--- a/src/modules/header-focus.js
+++ b/src/modules/header-focus.js
@@ -12,7 +12,7 @@ export function getHeaderElements() {
 function getHeaderElement() {
 	const selector = getHeaderSelector();
 	const position = ( selector === fallbackSelector ) ? 'top-right' : null;
-	return { id: 'header_image', selector, type: 'header', icon: 'headerIcon', position };
+	return { id: 'header_image', selector, type: 'header', icon: 'headerIcon', position, title: 'header image', };
 }
 
 function getHeaderSelector() {

--- a/src/modules/menu-focus.js
+++ b/src/modules/menu-focus.js
@@ -9,7 +9,8 @@ export function getMenuElements() {
 			id: menu.id,
 			selector: `.${menu.id}`,
 			type: 'menu',
-			handler: makeHandler( menu.location )
+			handler: makeHandler( menu.location ),
+			title: 'menu',
 		};
 	} );
 }

--- a/src/modules/post-focus.js
+++ b/src/modules/post-focus.js
@@ -19,7 +19,14 @@ export function getPostElements() {
 		if ( ! url ) {
 			return posts;
 		}
-		return posts.concat( { id: post.id, selector: `#${post.id} .entry-title`, type: 'post', position: 'middle', handler: makeHandler( post.id, url ) } );
+		return posts.concat( {
+			id: post.id,
+			selector: `#${post.id} .entry-title`,
+			type: 'post',
+			position: 'middle',
+			handler: makeHandler( post.id, url ),
+			title: 'post',
+		} );
 	}, [] );
 }
 

--- a/src/modules/widget-focus.js
+++ b/src/modules/widget-focus.js
@@ -11,7 +11,13 @@ export function getWidgetElements() {
 	return getWidgetSelectors()
 	.map( getWidgetsForSelector )
 	.reduce( ( widgets, id ) => widgets.concat( id ), [] ) // flatten the arrays
-	.map( id => ( { id, selector: getWidgetSelectorForId( id ), type: 'widget', handler: makeHandlerForId( id ) } ) );
+	.map( id => ( {
+		id,
+		selector: getWidgetSelectorForId( id ),
+		type: 'widget',
+		handler: makeHandlerForId( id ),
+		title: 'widget',
+	} ) );
 }
 
 function getWidgetSelectors() {

--- a/src/preview.js
+++ b/src/preview.js
@@ -16,7 +16,7 @@ const $ = getJQuery();
 
 function startDirectManipulation() {
 	const basicElements = [
-		{ id: 'blogname', selector: '.site-title, #site-title', type: 'siteTitle', position: 'middle' },
+		{ id: 'blogname', selector: '.site-title, #site-title', type: 'siteTitle', position: 'middle', title: 'site title' },
 	];
 	const headers = ( options.headerImageSupport ) ? getHeaderElements() : [];
 	const widgets = getWidgetElements();

--- a/test/icon-buttons-test.js
+++ b/test/icon-buttons-test.js
@@ -109,6 +109,17 @@ describe( 'positionIcon()', function() {
 			expect( $el.hasClass( 'cdm-icon--text' ) ).to.be.false;
 			expect( $el.hasClass( 'cdm-icon--header-image' ) ).to.be.true;
 		} );
+
+		it( 'creates an icon button with the title attribute', function() {
+			const element = {
+				id: 'test',
+				selector: '.site-title',
+				type: 'testType',
+				icon: 'headerIcon',
+			};
+			positionIcon( element );
+			expect( $( '.cdm-icon__test' ).attr('title') ).equals( 'Click to edit the test type' );
+		} );
 	} );
 
 	describe( 'when positioning the icon button', function() {


### PR DESCRIPTION
Currently the icons for hidden widgets are positioned with `left: -1000px` style, which causes horizontal scrolling.
This patch fixes the problem by using `right` property instead of `left` in RTL languages.

See: https://github.com/Automattic/customize-direct-manipulation/issues/28
