### PR TITLE
Fix hidden icons position in RTL languages.

### DIFF
--- a/src/helpers/icon-buttons.js
+++ b/src/helpers/icon-buttons.js
@@ -90,7 +90,7 @@ function getIconClassName( id ) {
 }
 
 function getCalculatedCssForIcon( position, $target, $icon ) {
-	const hiddenIconPos = ( 'rtl' === document.dir ) ? { right: -1000, left: 'auto' } : { left: -1000, right: 'auto' };
+	const hiddenIconPos = ( 'rtl' === getWindow().document.dir ) ? { right: -1000, left: 'auto' } : { left: -1000, right: 'auto' };
 
 	if ( ! $target.is( ':visible' ) ) {
 		return hiddenIconPos;

--- a/src/helpers/icon-buttons.js
+++ b/src/helpers/icon-buttons.js
@@ -90,26 +90,28 @@ function getIconClassName( id ) {
 }
 
 function getCalculatedCssForIcon( position, $target, $icon ) {
+	const hiddenIconPos = ( 'rtl' === document.dir ) ? { right: -1000, left: 'auto' } : { left: -1000, right: 'auto' };
+
 	if ( ! $target.is( ':visible' ) ) {
-		return { left: -1000 };
+		return hiddenIconPos;
 	}
 	const { left, top } = $target.offset();
 	const middle = $target.innerHeight() / 2;
 	const iconMiddle = $icon.innerHeight() / 2;
 	if ( top < 1 ) {
 		debug( 'top offset is unusually low for', $target, top );
-		return { left: -1000 };
+		return hiddenIconPos;
 	}
 	if ( middle < 1 ) {
 		debug( 'middle height is unusually low for', $target, middle );
-		return { left: -1000 };
+		return hiddenIconPos;
 	}
 	if ( position === 'middle' ) {
-		return adjustCoordinates( { top: top + middle - iconMiddle, left } );
+		return adjustCoordinates( { top: top + middle - iconMiddle, left, right: 'auto' } );
 	} else if ( position === 'top-right' ) {
-		return adjustCoordinates( { top, left: left + $target.width() + 70 } );
+		return adjustCoordinates( { top, left: left + $target.width() + 70, right: 'auto' } );
 	}
-	return adjustCoordinates( { top, left } );
+	return adjustCoordinates( { top, left, right: 'auto' } );
 }
 
 function adjustCoordinates( coords ) {

--- a/test/icon-buttons-test.js
+++ b/test/icon-buttons-test.js
@@ -2,6 +2,7 @@ import resetMarkup from './mock-window';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import chai from 'chai';
+import getWindow from '../src/helpers/window';
 import getJQuery from '../src/helpers/jquery';
 import { positionIcon } from '../src/helpers/icon-buttons';
 
@@ -144,6 +145,25 @@ describe( 'positionIcon()', function() {
 			expect( cssSpy ).to.have.been.calledWith( { left: -1000, right: 'auto' } );
 		} );
 
+		it( 'positions the icon off-screen when the target element is hidden (RTL)', function() {
+			const documentDir = getWindow().document.dir;
+			getWindow().document.dir = 'rtl';
+
+			mockTarget.is = prop => ( prop !== ':visible' );
+			const element = {
+				id: 'test',
+				selector: '.site-title',
+				type: 'testType',
+				$target: mockTarget,
+				$icon: mockIcon,
+			};
+			positionIcon( element );
+			expect( cssSpy ).to.have.been.calledWith( { left: 'auto', right: -1000 } );
+
+			// restore dir
+			getWindow().document.dir = documentDir;
+		} );
+
 		it( 'positions the icon off-screen when the target element has a very low top offset', function() {
 			mockTarget.offset = () => ( { top: 0, left: 100 } );
 			const element = {
@@ -157,6 +177,25 @@ describe( 'positionIcon()', function() {
 			expect( cssSpy ).to.have.been.calledWith( { left: -1000, right: 'auto' } );
 		} );
 
+		it( 'positions the icon off-screen when the target element has a very low top offset (RTL)', function() {
+			const documentDir = getWindow().document.dir;
+			getWindow().document.dir = 'rtl';
+
+			mockTarget.offset = () => ( { top: 0, left: 100 } );
+			const element = {
+				id: 'test',
+				selector: '.site-title',
+				type: 'testType',
+				$target: mockTarget,
+				$icon: mockIcon,
+			};
+			positionIcon( element );
+			expect( cssSpy ).to.have.been.calledWith( { left: 'auto', right: -1000 } );
+
+			// restore dir
+			getWindow().document.dir = documentDir;
+		} );
+
 		it( 'positions the icon off-screen when the target element is very small', function() {
 			mockTarget.innerHeight = () => -1;
 			const element = {
@@ -168,6 +207,25 @@ describe( 'positionIcon()', function() {
 			};
 			positionIcon( element );
 			expect( cssSpy ).to.have.been.calledWith( { left: -1000, right: 'auto' } );
+		} );
+
+		it( 'positions the icon off-screen when the target element is very small (RTL)', function() {
+			const documentDir = getWindow().document.dir;
+			getWindow().document.dir = 'rtl';
+
+			mockTarget.innerHeight = () => -1;
+			const element = {
+				id: 'test',
+				selector: '.site-title',
+				type: 'testType',
+				$target: mockTarget,
+				$icon: mockIcon,
+			};
+			positionIcon( element );
+			expect( cssSpy ).to.have.been.calledWith( { left: 'auto', right: -1000 } );
+
+			// restore dir
+			getWindow().document.dir = documentDir;
 		} );
 
 		it( 'positions the icon at the top-left of the target', function() {

--- a/test/icon-buttons-test.js
+++ b/test/icon-buttons-test.js
@@ -141,7 +141,7 @@ describe( 'positionIcon()', function() {
 				$icon: mockIcon,
 			};
 			positionIcon( element );
-			expect( cssSpy ).to.have.been.calledWith( { left: -1000 } );
+			expect( cssSpy ).to.have.been.calledWith( { left: -1000, right: 'auto' } );
 		} );
 
 		it( 'positions the icon off-screen when the target element has a very low top offset', function() {
@@ -154,7 +154,7 @@ describe( 'positionIcon()', function() {
 				$icon: mockIcon,
 			};
 			positionIcon( element );
-			expect( cssSpy ).to.have.been.calledWith( { left: -1000 } );
+			expect( cssSpy ).to.have.been.calledWith( { left: -1000, right: 'auto' } );
 		} );
 
 		it( 'positions the icon off-screen when the target element is very small', function() {
@@ -167,7 +167,7 @@ describe( 'positionIcon()', function() {
 				$icon: mockIcon,
 			};
 			positionIcon( element );
-			expect( cssSpy ).to.have.been.calledWith( { left: -1000 } );
+			expect( cssSpy ).to.have.been.calledWith( { left: -1000, right: 'auto' } );
 		} );
 
 		it( 'positions the icon at the top-left of the target', function() {
@@ -179,7 +179,7 @@ describe( 'positionIcon()', function() {
 				$icon: mockIcon,
 			};
 			positionIcon( element );
-			expect( cssSpy ).to.have.been.calledWith( { top: 100, left: 100 } );
+			expect( cssSpy ).to.have.been.calledWith( { top: 100, left: 100, right: 'auto' } );
 		} );
 
 		it( 'positions the icon at the left edge of the viewport if it would be off the left side', function() {
@@ -193,7 +193,7 @@ describe( 'positionIcon()', function() {
 				$icon: mockIcon,
 			};
 			positionIcon( element );
-			expect( cssSpy ).to.have.been.calledWith( { top: 100, left: 35 } );
+			expect( cssSpy ).to.have.been.calledWith( { top: 100, left: 35, right: 'auto' } );
 		} );
 
 		it( 'positions the icon at the left middle of the target if the position is `middle`', function() {
@@ -206,7 +206,7 @@ describe( 'positionIcon()', function() {
 				$icon: mockIcon,
 			};
 			positionIcon( element );
-			expect( cssSpy ).to.have.been.calledWith( { top: 111, left: 100 } );
+			expect( cssSpy ).to.have.been.calledWith( { top: 111, left: 100, right: 'auto' } );
 		} );
 
 		it( 'positions the icon at the top-right of the target if the position is `top-right`', function() {
@@ -219,7 +219,7 @@ describe( 'positionIcon()', function() {
 				$icon: mockIcon,
 			};
 			positionIcon( element );
-			expect( cssSpy ).to.have.been.calledWith( { top: 100, left: 370 } );
+			expect( cssSpy ).to.have.been.calledWith( { top: 100, left: 370, right: 'auto' } );
 		} );
 
 		it( 'positions the icon at the right edge of the viewport if it would be off the right side', function() {
@@ -234,7 +234,7 @@ describe( 'positionIcon()', function() {
 				$icon: mockIcon,
 			};
 			positionIcon( element );
-			expect( cssSpy ).to.have.been.calledWith( { top: 100, left: 914 } );
+			expect( cssSpy ).to.have.been.calledWith( { top: 100, left: 914, right: 'auto' } );
 		} );
 	} );
 } );


### PR DESCRIPTION
Currently the icons for hidden widgets are positioned with `left: -1000px` style, which causes horizontal scrolling.
This patch fixes the problem by using `right` property instead of `left` in RTL languages.

See: https://github.com/Automattic/customize-direct-manipulation/issues/28
