### PR TITLE
Add support for Jetpack Site Logo

### DIFF
--- a/css/customize-direct-manipulation.css
+++ b/css/customize-direct-manipulation.css
@@ -46,6 +46,10 @@
 	margin: 10px;
 }
 
+.cdm-icon--header-image.cdm-icon__site_logo {
+	margin: -15px 0 0 -15px;
+}
+
 @keyframes bounce-appear {
 	from, 20%, 40%, 60%, 80%, to {
 		animation-timing-function: cubic-bezier(0.215, 0.610, 0.355, 1.000);

--- a/src/helpers/options.js
+++ b/src/helpers/options.js
@@ -3,3 +3,7 @@ import getWindow from './window';
 export default function getOptions() {
 	return getWindow()._Customizer_DM;
 }
+
+export function isDisabled( moduleName ) {
+	return ( -1 !== getOptions().disabledModules.indexOf( moduleName ) );
+}

--- a/src/modules/site-logo-focus.js
+++ b/src/modules/site-logo-focus.js
@@ -1,0 +1,11 @@
+export function getSiteLogoElements() {
+	return [
+		{
+			id: 'site_logo',
+			selector: '.site-logo-link',
+			type: 'siteLogo',
+			icon: 'headerIcon',
+			title: 'site logo',
+		}
+	];
+}

--- a/src/preview.js
+++ b/src/preview.js
@@ -1,7 +1,7 @@
 import getWindow from './helpers/window';
 import getAPI from './helpers/api';
 import getJQuery from './helpers/jquery';
-import getOptions from './helpers/options';
+import getOptions, { isDisabled } from './helpers/options';
 import { isSafari, isMobileSafari } from './helpers/user-agent';
 import makeFocusable from './modules/focusable';
 import { modifyEditPostLinks, disableEditPostLinks } from './modules/edit-post-links';
@@ -9,6 +9,7 @@ import { getHeaderElements } from './modules/header-focus';
 import { getWidgetElements } from './modules/widget-focus';
 import { getMenuElements } from './modules/menu-focus';
 import { getFooterElements } from './modules/footer-focus';
+import { getSiteLogoElements } from './modules/site-logo-focus';
 
 const options = getOptions();
 const api = getAPI();
@@ -18,13 +19,14 @@ function startDirectManipulation() {
 	const basicElements = [
 		{ id: 'blogname', selector: '.site-title, #site-title', type: 'siteTitle', position: 'middle', title: 'site title' },
 	];
-	const headers = ( options.headerImageSupport ) ? getHeaderElements() : [];
-	const widgets = ( -1 === options.disabledModules.indexOf( 'widget-focus' ) ) ? getWidgetElements() : [];
-	const menus   = ( -1 === options.disabledModules.indexOf( 'menu-focus' ) )   ? getMenuElements() : [];
-	const footers = ( -1 === options.disabledModules.indexOf( 'footer-focus' ) ) ? getFooterElements() : [];
-	makeFocusable( basicElements.concat( headers, widgets, menus, footers ) );
+	const headers  = ! options.headerImageSupport    ? [] : getHeaderElements();
+	const widgets  = isDisabled( 'widget-focus' )    ? [] : getWidgetElements();
+	const menus    = isDisabled( 'menu-focus' )      ? [] : getMenuElements();
+	const footers  = isDisabled( 'footer-focus' )    ? [] : getFooterElements();
+	const siteLogo = isDisabled( 'site-logo-focus' ) ? [] : getSiteLogoElements();
+	makeFocusable( basicElements.concat( headers, widgets, menus, footers, siteLogo ) );
 
-	if ( -1 === options.disabledModules.indexOf( 'edit-post-links' ) ) {
+	if ( ! isDisabled( 'edit-post-links' ) ) {
 		if ( isSafari() && ! isMobileSafari() ) {
 			disableEditPostLinks( '.post-edit-link, [href^="https://wordpress.com/post"], [href^="https://wordpress.com/page"]' );
 		} else {


### PR DESCRIPTION
Related: #13

## How to Test
1. Set a theme that supports Jetpack site logo. i.e. Edin
2. Add a site logo.
3. There should be an icon button on the site logo.
4. The icon should be hidden when the site logo removed.

![support_for_site_logo](https://cloud.githubusercontent.com/assets/212034/20591601/bfc736e0-b26c-11e6-9de5-0fc17faa2e4a.png)
