### PR TITLE
Add support for partial update

### DIFF
--- a/src/helpers/icon-buttons.js
+++ b/src/helpers/icon-buttons.js
@@ -37,11 +37,7 @@ export function positionIcon( element ) {
 		return element;
 	}
 
-	let $partialContainer = null;
-	if ( $target.data( 'customize-partial-id' ) ) {
-		$partialContainer = $target;
-	}
-
+	const $partialContainer = ( $target.data( 'customize-partial-id' ) ) ? $target : null;
 	const $icon = findOrCreateIcon( element );
 	const css = getCalculatedCssForIcon( element, $target, $icon );
 	debug( `positioning icon for ${element.id} with CSS ${JSON.stringify( css )}` );

--- a/src/helpers/icon-buttons.js
+++ b/src/helpers/icon-buttons.js
@@ -36,11 +36,17 @@ export function positionIcon( element ) {
 		debug( `Could not find target element for icon ${element.id} with selector ${element.selector}` );
 		return element;
 	}
+
+	let $partialContainer = null;
+	if ( $target.data( 'customize-partial-id' ) ) {
+		$partialContainer = $target;
+	}
+
 	const $icon = findOrCreateIcon( element );
 	const css = getCalculatedCssForIcon( element, $target, $icon );
 	debug( `positioning icon for ${element.id} with CSS ${JSON.stringify( css )}` );
 	$icon.css( css );
-	return _.extend( {}, element, { $target, $icon } );
+	return _.extend( {}, element, { $target, $icon, $partialContainer } );
 }
 
 export function addClickHandlerToIcon( element ) {
@@ -195,5 +201,6 @@ function getElementTarget( element ) {
 		// target was removed from DOM, likely by partial refresh
 		element.$target = null;
 	}
+
 	return element.$target || $( element.selector );
 }

--- a/src/modules/focusable.js
+++ b/src/modules/focusable.js
@@ -128,20 +128,21 @@ function makeDefaultHandler( id ) {
 
 function createPartialUpdateHandler( elements ) {
 	return ( partial ) => {
+		// Get the elements that refer partial containers.
 		const elementsToUpdate = elements.filter( element => {
 			const $container = element.$partialContainer;
 
-			if ( ! $container || $container.data( 'customize-partial-id' ) !== partial.id ) {
-				return false;
-			}
+			return ( $container && $container.data( 'customize-partial-id' ) === partial.id );
+		} );
 
+		// Trigger onPartialUpdate on the elements if possible
+		elementsToUpdate.map( element => {
 			if ( 'function' === typeof element.onPartialUpdate ) {
 				element.onPartialUpdate.call( element, partial, element, elements );
 			}
-
-			return true;
 		} );
 
+		// Reposition the icons that are associated with the partial containers.
 		if ( elementsToUpdate.length > 0 )  {
 			repositionAfterFontsLoad( elementsToUpdate );
 		}

--- a/src/modules/focusable.js
+++ b/src/modules/focusable.js
@@ -97,7 +97,7 @@ function startIconMonitor( elements ) {
 	}
 
 	// Support partial update
-	const partialUpdateHandler = createPartialUpdateHandler( elements )
+	const partialUpdateHandler = createPartialUpdateHandler( elements );
 	api.selectiveRefresh.partial.bind( 'add', partialUpdateHandler );
 	api.selectiveRefresh.partial.each( ( partial ) => {
 		partial.deferred.ready.done( () => partialUpdateHandler( partial ) );

--- a/src/modules/focusable.js
+++ b/src/modules/focusable.js
@@ -1,7 +1,6 @@
 import getWindow from '../helpers/window';
 import getAPI from '../helpers/api';
 import getJQuery from '../helpers/jquery';
-import getUnderscore from '../helpers/underscore';
 import { send } from '../helpers/messenger';
 import { positionIcon, addClickHandlerToIcon, repositionAfterFontsLoad, enableIconToggle } from '../helpers/icon-buttons';
 import debugFactory from 'debug';
@@ -9,7 +8,6 @@ import debugFactory from 'debug';
 const debug = debugFactory( 'cdm:focusable' );
 const api = getAPI();
 const $ = getJQuery();
-const _ = getUnderscore();
 
 /**
  * Give DOM elements an icon button bound to click handlers

--- a/src/modules/menu-focus.js
+++ b/src/modules/menu-focus.js
@@ -11,6 +11,7 @@ export function getMenuElements() {
 			type: 'menu',
 			handler: makeHandler( menu.location ),
 			title: 'menu',
+			onPartialUpdate: onPartialUpdate,
 		};
 	} );
 }
@@ -19,4 +20,16 @@ function makeHandler( id ) {
 	return function() {
 		send( 'focus-menu', id );
 	};
+}
+
+function onPartialUpdate( partial, element, elements ) {
+	// Select the first menu item as a target if exists.
+	// This will prevent menu icons from offsetting too far.
+	// See https://github.com/Automattic/customize-direct-manipulation/issues/3
+	if ( element.$partialContainer ) {
+		const $firstMenuItem = element.$partialContainer.find('.menu-item:visible:first');
+		if ( $firstMenuItem.length && ! $firstMenuItem.is( element.$target ) ) {
+			element.$target = $firstMenuItem;
+		}
+	}
 }

--- a/src/modules/menu-focus.js
+++ b/src/modules/menu-focus.js
@@ -11,7 +11,7 @@ export function getMenuElements() {
 			type: 'menu',
 			handler: makeHandler( menu.location ),
 			title: 'menu',
-			onPartialUpdate: onPartialUpdate,
+			onPartialUpdate,
 		};
 	} );
 }


### PR DESCRIPTION
A focus element's `onPartialUpdate` function property will be triggered
when an associated partial container is prepared or added.

See #23

I updated `menu-focus` module to show how to use the feature and also fixed icons positioned too far (see #3). The following images show what you get from this PR.

_Before_
![icons positioned too far](https://cloud.githubusercontent.com/assets/212034/20645070/804b8a9c-b493-11e6-9599-55fedd7ca4f3.png)

_After_
![icons correctly positioned](https://cloud.githubusercontent.com/assets/212034/20645071/93ecb6a2-b493-11e6-8181-f53e3d09bf61.png)

# How to test

1. Set a theme that has a right or center aligned nav menu. i.e. Dyad.
2. Open the customizer and see where the CDM icon for the primary nav menu is.
3. Apply this PR.
4. Repeat step 2. It should be close to the nav menu.
