### PR TITLE
Disable core edit shortcuts when this plugin is active

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -63,7 +63,7 @@ module.exports = function( grunt ) {
 	} );
 
 	grunt.registerTask( 'default', [ 'browserify:devPreview', 'browserify:devAdmin', 'copytotheplace', 'watch' ] );
-	grunt.registerTask( 'dist', [ 'browserify:devPreview', 'browserify:devAdmin', 'uglify:dist' ] );
+	grunt.registerTask( 'dist', [ 'browserify:devPreview', 'browserify:devAdmin', 'uglify:dist', 'copytotheplace' ] );
 	grunt.registerTask( 'test', [ 'mochaTest' ] );
 };
 

--- a/customize-direct-manipulation.php
+++ b/customize-direct-manipulation.php
@@ -128,7 +128,7 @@ class Jetpack_Customizer_DM {
 	}
 
 	public function admin_enqueue() {
-		wp_enqueue_script( 'customize-dm-admin', plugins_url( 'js/customize-dm-admin.js', __FILE__ ), array( 'customize-controls', 'customize-selective-refresh' ), '20161129', true );
+		wp_enqueue_script( 'customize-dm-admin', plugins_url( 'js/customize-dm-admin.js', __FILE__ ), array( 'customize-controls' ), '20161129', true );
 		wp_enqueue_style( 'customize-dm-admin', plugins_url( 'css/cdm-admin.css', __FILE__ ) );
 
 		$steps = array(
@@ -145,7 +145,7 @@ class Jetpack_Customizer_DM {
 
 	public function preview_enqueue() {
 		wp_enqueue_style( 'customize-dm-preview', plugins_url( 'css/customize-direct-manipulation.css', __FILE__ ), array(), '20160411' );
-		wp_enqueue_script( 'customize-dm-preview', plugins_url( 'js/customize-dm-preview.js', __FILE__ ), array( 'jquery' ), '20160411', true );
+		wp_enqueue_script( 'customize-dm-preview', plugins_url( 'js/customize-dm-preview.js', __FILE__ ), array( 'jquery', 'customize-selective-refresh' ), '20161205', true );
 		add_action( 'wp_footer', array( $this, 'add_script_data_in_footer' ) );
 		add_filter( 'widget_links_args', array( $this, 'fix_widget_links' ) );
 	}

--- a/customize-direct-manipulation.php
+++ b/customize-direct-manipulation.php
@@ -128,7 +128,7 @@ class Jetpack_Customizer_DM {
 	}
 
 	public function admin_enqueue() {
-		wp_enqueue_script( 'customize-dm-admin', plugins_url( 'js/customize-dm-admin.js', __FILE__ ), array( 'customize-controls' ), '20160411', true );
+		wp_enqueue_script( 'customize-dm-admin', plugins_url( 'js/customize-dm-admin.js', __FILE__ ), array( 'customize-controls', 'customize-selective-refresh' ), '20161129', true );
 		wp_enqueue_style( 'customize-dm-admin', plugins_url( 'css/cdm-admin.css', __FILE__ ) );
 
 		$steps = array(

--- a/src/preview.js
+++ b/src/preview.js
@@ -10,12 +10,25 @@ import { getWidgetElements } from './modules/widget-focus';
 import { getMenuElements } from './modules/menu-focus';
 import { getFooterElements } from './modules/footer-focus';
 import { getSiteLogoElements } from './modules/site-logo-focus';
+import debugFactory from 'debug';
+const debug = debugFactory( 'cdm:preview' );
 
 const options = getOptions();
 const api = getAPI();
 const $ = getJQuery();
 
+function disableEditShortcuts() {
+	if ( api.selectiveRefresh && api.selectiveRefresh.Partial && api.selectiveRefresh.Partial.prototype.createEditShortcutForPlacement ) {
+		debug( 'disabling edit shortcuts' );
+		api.selectiveRefresh.Partial.prototype.createEditShortcutForPlacement = function() {};
+	} else {
+		debug( 'no edit shortcuts support detected' );
+	}
+}
+
 function startDirectManipulation() {
+	disableEditShortcuts();
+
 	const basicElements = [
 		{ id: 'blogname', selector: '.site-title, #site-title', type: 'siteTitle', position: 'middle', title: 'site title' },
 	];


### PR DESCRIPTION
Fixes #37 

Well, it avoids conflicting with edit shortcuts for now. Switching to them will likely mean deprecating this plugin so this should be good for now.

Before:
<img width="795" alt="screen shot 2016-11-29 at 2 33 47 pm" src="https://cloud.githubusercontent.com/assets/2036909/20725755/e34153b2-b640-11e6-98ae-7b557b351bbf.png">

After:
<img width="794" alt="screen shot 2016-11-29 at 2 33 17 pm" src="https://cloud.githubusercontent.com/assets/2036909/20725748/df6f1b0c-b640-11e6-85cb-5b5d82636f81.png">


## Testing

- Install latest trunk of WordPress 4.7 (or the latest RC).
- Install and activate this plugin.
- Load the Customizer.
- Be sure only one set of icons is visible.
