### PR TITLE
Add non-production files to svn:ignore automatically.

### DIFF
--- a/.svnignore
+++ b/.svnignore
@@ -1,0 +1,9 @@
+.*
+*.md
+*.log
+src
+test
+Gruntfile.js
+package.json
+circle.yml
+node_modules

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "scripts": {
     "start": "grunt",
     "dist": "grunt dist",
-    "test": "grunt test"
+    "test": "grunt test",
+    "postinstall": "svn info . 1>/dev/null 2>&1 && svn propset svn:ignore -F .svnignore ."
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "grunt",
     "dist": "grunt dist",
     "test": "grunt test",
-    "postinstall": "svn info . 1>/dev/null 2>&1 && svn propset svn:ignore -F .svnignore ."
+    "postinstall": "(svn info . 1>/dev/null 2>&1 && svn propset svn:ignore -F .svnignore .) || echo 'Not a working copy.'"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
You probably keep seeing the annoying unstaged files when you put this repo under another subversion repo. This PR will automatically add the content of `.svnignore` to `svn:ignore` property  so the unstaged files never show again on `svn st` call.