### PR TITLE
Add ability to add extra guided tours

### DIFF
--- a/customize-direct-manipulation.php
+++ b/customize-direct-manipulation.php
@@ -106,10 +106,10 @@ class Jetpack_Customizer_DM {
 	}
 
 	private function should_show_guide() {
-		// a8c testing
-		if ( function_exists( 'is_automattician' ) && is_automattician() && isset( $_GET['guide'] ) ) {
+		if ( isset( $_GET['guide'] ) ) {
 			return true;
 		}
+
 		// Only to newer users
 		$this_user_id = (int) get_current_user_id();
 		$minimum_user_id = 99855465;
@@ -138,6 +138,8 @@ class Jetpack_Customizer_DM {
 				'button' => __( 'Thanks, got it!' )
 			),
 		);
+
+		$steps = apply_filters( 'customizer_direct_manipulation_steps', $steps );
 
 		$showGuide = $this->should_show_guide();
 		wp_localize_script( 'customize-dm-admin', '_Customizer_DM', compact( 'steps', 'showGuide' ) );

--- a/src/modules/guide-steps.js
+++ b/src/modules/guide-steps.js
@@ -6,13 +6,15 @@ const smallScreenWidth = 640;
 
 export function nextStep() {
 	currentStep++;
+	getJQ()( '#dmguide .dmguide-step' ).html( getStepHtml() );
+	getJQ()( '#dmguide' ).offset( getStepPosition() );
 }
 
 export function isLastStep() {
 	return currentStep >= getOptions().steps.length;
 }
 
-function getTotalSteps() {
+export function getTotalSteps() {
 	return getOptions().steps.length;
 }
 
@@ -24,7 +26,7 @@ function getCurrentStepData() {
 	return getStepData( currentStep );
 }
 
-function getCurrentStep() {
+export function getCurrentStep() {
 	return currentStep;
 }
 
@@ -55,6 +57,11 @@ export function getStepHtml() {
 	html += '</div>';
 
 	return html;
+}
+
+export function getStepPosition() {
+	const { styleTop, styleLeft } = getCurrentStepData();
+	return { top: styleTop || 97, left: styleLeft || 307 };
 }
 
 function getButtons() {

--- a/src/modules/guide.js
+++ b/src/modules/guide.js
@@ -1,10 +1,12 @@
-import { getHtml } from './guide-steps';
+import { getHtml, getCurrentStep, getTotalSteps, nextStep, isLastStep, getStepPosition } from './guide-steps';
 import getJQ from '../helpers/jquery';
 import { recordEvent } from '../helpers/record-event';
 import { animateWithClass, supportsAnimation } from '../helpers/animate';
+import getOptions from '../helpers/options';
 
 function showGuide() {
 	getJQ()( 'body' ).append( getHtml() );
+	getJQ()( '#dmguide' ).offset( getStepPosition() );
 	addEvents();
 
 	if ( supportsAnimation() ) {
@@ -15,15 +17,20 @@ function showGuide() {
 }
 
 function addEvents() {
-	getJQ()( '#dmguide' ).on( 'click.dmguide', '.dmguide-button', dismiss );
-	getJQ()( '#dmguide-overlay' ).on( 'click.dmguide', dismiss );
-	getJQ()( document ).on( 'click.dmguide', dismiss ).on( 'keyup.dmguide', onKeyUp );
+	getJQ()( '#dmguide' ).on( 'click.dmguide', '.dmguide-button', maybeGoToNextStep );
+	getJQ()( '#dmguide-overlay' ).on( 'click.dmguide', maybeAllowDismissal );
 }
 
 function dismiss() {
 	removeGuide();
 	getJQ()( document ).off( '.dmguide' );
 	recordEvent( 'wpcom_customize_guide_dismiss' );
+}
+
+function maybeAllowDismissal() {
+	if ( isLastStep() ) {
+		dismiss();
+	}
 }
 
 function removeGuide() {
@@ -46,6 +53,14 @@ function onKeyUp( event ) {
 	}
 }
 
+function maybeGoToNextStep() {
+	if ( getTotalSteps() > getCurrentStep() ) {
+		nextStep();
+	}
+}
+
+
 export default function addGuide( countdown = 2500 ) {
+	countdown = getOptions().steps[0].startDelay || countdown;
 	setTimeout( showGuide, countdown );
 }


### PR DESCRIPTION
Currently customize-direct-manipulation has only one, single-step,
absolute positioned Guided Tour. This change will add support for
creating more with plugins and without changing this repo.

An additional Guided Tour:
- will work with a query string wp-admin/customize.php?guide=social-menu
- will work if the menu is autofocused (removes the automatic dismissal
onkeyup)
- can have configurable absolute positioning and start delay
- the additional tours have to be defined as a separate plugin:

```
$steps = apply_filters( 'customizer_direct_manipulation_steps', $steps );
```

Test plan:
The only tour should work like before when loading customize.php?guide=1
- the change removes the need of is_automattician() to trigger it.

Note: it doesn't fix the broken tests