### PR TITLE
Fix block widget edit shortcuts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2,7 +2,6 @@
   "name": "customize-direct-manipulation",
   "version": "1.1.0",
   "lockfileVersion": 1,
-  "requires": true,
   "dependencies": {
     "@babel/code-frame": {
       "version": "7.0.0-beta.31",
@@ -3281,6 +3280,15 @@
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
       "dev": true
     },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -3306,15 +3314,6 @@
             "ansi-regex": "3.0.0"
           }
         }
-      }
-    },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {

--- a/src/admin.js
+++ b/src/admin.js
@@ -1,6 +1,6 @@
 import $ from 'jquery';
 import getAPI from './helpers/api';
-import { off, send } from './helpers/messenger';
+import { send } from './helpers/messenger';
 import addFocusListener from './modules/focus-listener';
 import { bindPreviewEventsListener } from './helpers/record-event';
 import addGuide from './modules/guide';
@@ -17,11 +17,6 @@ api.bind( 'ready', () => {
 	addFocusListener( 'control-focus', id => api.control( id ) );
 	addFocusListener( 'focus-menu', id => api.section( id ) );
 	addFocusListener( 'focus-menu-location', id => api.control( `nav_menu_locations[${ id }]` ) );
-
-	// disable core so we can enhance by making sure the controls panel opens
-	// before trying to focus the widget
-	off( 'focus-widget-control', api.Widgets.focusWidgetFormControl );
-	addFocusListener( 'focus-widget-control', id => api.Widgets.getWidgetFormControlForWidget( id ) );
 
 	// Toggle icons when customizer toggles preview mode
 	$( '.collapse-sidebar' ).on( 'click', () => send( 'cdm-toggle-visible' ) );

--- a/src/helpers/icon-buttons.js
+++ b/src/helpers/icon-buttons.js
@@ -47,6 +47,7 @@ export function addClickHandlerToIcon( element ) {
 	if ( ! element.$icon ) {
 		return element;
 	}
+
 	addClickHandler( `.${ getIconClassName( element.id ) }`, element.handler );
 	return element;
 }

--- a/src/modules/focus-listener.js
+++ b/src/modules/focus-listener.js
@@ -20,6 +20,7 @@ function makeHandler( eventName, getControlCallback ) {
 		const eventTargetId = args[ 0 ];
 		debug( `received ${ eventName } event for target id ${ eventTargetId }` );
 		const focusableControl = getControlCallback.apply( getControlCallback, args );
+
 		if ( ! focusableControl ) {
 			debug( `no control found for event ${ eventName } and args:`, args );
 			return;


### PR DESCRIPTION
### Changes introduced

An attempt at disabling overriding the default/core shortcut placements for widget controls. Addresses https://github.com/Automattic/wp-calypso/issues/55365

### Test

1. Apply D66741-code to your sandbox
2. Open a sandboxed site and go the customizer (withe the `?guide` parameter) e.g. https://[foo.wordpress.com]/wp-admin/customize.php?guide
3. Add block widgets in the footer and test it out.

![Kapture 2021-09-13 at 14 39 22](https://user-images.githubusercontent.com/1705499/133079741-f2dc8212-7c5d-4eb4-b9d2-e35ee523f007.gif)

### Known regressions/follow ups

1. The styling of the widget shortcut buttons is different from the plugin's (also transitions a little differently). A follow-up could address this in the context of merging the two methods: either introduce title/footer shortcuts in core (?) or use the new partials API in this plugin.
2. Only tested this on a simple site with a couple of themes - no idea if any regressions in JP or elsewhere.

<img width="1239" alt="Screenshot 2021-09-13 at 2 50 03 PM" src="https://user-images.githubusercontent.com/1705499/133079763-d5b42aaa-237f-4476-9ffb-93747207c40b.png">