### PR TITLE
Use menu item element position to place the guide

### DIFF
--- a/src/modules/guide-steps.js
+++ b/src/modules/guide-steps.js
@@ -61,7 +61,16 @@ export function getStepHtml() {
 }
 
 export function getStepPosition() {
-	const { styleTop, styleLeft } = getCurrentStepData();
+	const { styleTop, styleLeft, elementId } = getCurrentStepData();
+	if ( elementId ) {
+		const guideElement = document.getElementById( elementId );
+		if ( guideElement ) {
+			const guidePosition = guideElement.getBoundingClientRect();
+			const offset = window.innerWidth < 601 ? 40 : -10;
+			return { top: ( guidePosition.top + offset ), left: styleLeft || 307 };
+		}
+	}
+
 	return { top: styleTop || 97, left: styleLeft || 307 };
 }
 


### PR DESCRIPTION
Currently when the tooltip of the menu item is not placed in the correct place. 

This Pr fixes this by relying on the element's position rendered in the browser. 


To test 
run 
```
npm install
npm run dist
```

Or test our the PR. 
